### PR TITLE
Display fetch error message

### DIFF
--- a/Screens/MusicScreen.js
+++ b/Screens/MusicScreen.js
@@ -10,7 +10,7 @@ const MusicScreen = ({navigation}) => {
   const { data, loading, error } = useFetchData('https://otttelemaerica.com/feed/SubAmerica.json');
 
   if (loading) return <ActivityIndicator size="large" color="#0000ff" />;
-  if (error) return <Text>Error loading data</Text>;
+  if (error) return <Text>{error.message}</Text>;
 
   return (
     <View style={styles.container}>

--- a/Screens/PerformanceScreen.js
+++ b/Screens/PerformanceScreen.js
@@ -10,7 +10,7 @@ const PerformanceScreen = ({navigation}) => {
   const { data, loading, error } = useFetchData('https://otttelemaerica.com/feed/SubAmerica.json');
 
   if (loading) return <ActivityIndicator size="large" color="#0000ff" />;
-  if (error) return <Text>Error loading data</Text>;
+  if (error) return <Text>{error.message}</Text>;
 
   return (
     <View style={styles.container}>

--- a/Screens/PodcastsScreen.js
+++ b/Screens/PodcastsScreen.js
@@ -10,7 +10,7 @@ const PodcastsScreen = ({navigation}) => {
   const { data, loading, error } = useFetchData('https://otttelemaerica.com/feed/SubAmerica.json');
 
   if (loading) return <ActivityIndicator size="large" color="#0000ff" />;
-  if (error) return <Text>Error loading data</Text>;
+  if (error) return <Text>{error.message}</Text>;
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
## Summary
- show `error.message` if data fetch fails on audio/video screens

## Testing
- `npm test` *(fails: jest not found)*