### PR TITLE
Fix Title component style property

### DIFF
--- a/components/Title.js
+++ b/components/Title.js
@@ -20,7 +20,7 @@ const styles = StyleSheet.create({
         width: 371,
         height: 40,
         color: 'white',
-        font: 'bold',
+        fontWeight: 'bold',
         fontSize: 26,
         marginLeft: 90,
     }


### PR DESCRIPTION
## Summary
- fix Title component style object to use `fontWeight`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*